### PR TITLE
fix argument out of range error for malformed date string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 .ruby-version
 tags
 *.swp
+.idea

--- a/lib/field_mapper/standard/field.rb
+++ b/lib/field_mapper/standard/field.rb
@@ -157,7 +157,7 @@ module FieldMapper
       def time(value)
         return value.utc if value.is_a?(Time)
         return value.to_time.utc if value.is_a?(Date)
-        return value.to_time(:utc) if value.is_a?(String)
+        return value.to_time(:utc) rescue nil if value.is_a?(String)
         nil
       end
 

--- a/lib/field_mapper/version.rb
+++ b/lib/field_mapper/version.rb
@@ -1,3 +1,3 @@
 module FieldMapper
-  VERSION = "0.4.2"
+  VERSION = "0.4.3"
 end

--- a/test/standard/field_test.rb
+++ b/test/standard/field_test.rb
@@ -152,5 +152,10 @@ module Standard
       field = FieldMapper::Standard::Field.new(:foo, type: String)
       assert field.to_s == field.name
     end
+
+    test 'stupid date string returns nil' do
+      field = FieldMapper::Standard::Field.new(:foo, type: Time)
+      assert field.cast('2032-Aug-32').nil?
+    end
   end
 end


### PR DESCRIPTION
Hey Nate, this is Shaun Carlson, hope all is well.  I'm working at Partner Fusion now and came across this error in your field mapper gem, so I wanted to share this fix back with you.  Basically whenever you have a date string that's *almost* correct, you get an argument out of range error.